### PR TITLE
Fix issue #7: Can't pass same arguments to each iteration of batch workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,18 @@ end
 MyBatchSuperworker.perform_async([30, 31, 32, 33, 34, 35])
 ```
 
+You can also pass arguments from superworker to batch subworkers, if you declare them in `batch` block's arguments before the array on which to iterate. The following will run Worker1 with additional arguments for each user ID:
+
+```ruby
+Superworker.create(:MyBatchSuperworkerWithArgs, :user_ids, :title, :message) do
+  batch title: :title, message: :message, user_ids: :user_id do
+    Worker1 :user_id, :title, :message
+  end
+end
+
+MyBatchSuperworkerWithArgs.perform_async([30, 31, 32, 33], 'Hello', 'world')
+```
+
 Grouping jobs into batches greatly improves your ability to audit them and determine when batches have finished.
 
 ### Superjob Names

--- a/lib/sidekiq/superworker/dsl_hash.rb
+++ b/lib/sidekiq/superworker/dsl_hash.rb
@@ -143,7 +143,7 @@ module Sidekiq
         batch_values = batch_keys_to_batch_values.values
         first_batch_value = batch_values.pop
         if batch_values.length > 0
-          batch_values = first_batch_value.zip(batch_values)
+          batch_values = first_batch_value.map { |value| [value] + batch_values }
         else
           batch_values = first_batch_value.zip
         end


### PR DESCRIPTION
While not completely undestanding, how the DSL and particularly, passing args to batch workers, work, with this patch I made it possible to pass the arguments received by superworker class on to batch subworkers. Spec test and documentation included.
