### PR TITLE
Add option to expire subjob keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,16 @@ When a superjob is queued, records for all of its subjobs are created. By defaul
 Sidekiq::Superworker.options[:delete_subjobs_after_superjob_completes] = false
 ```
 
+#### Expire superworkers
+
+When a subjob dies due to too many retries depending jobs will never run and the superjob will never be completed. Therefore the sujob redis keys will never be removed.
+When setting `superjob_expiration` to *x* the subjobs keys will expire in *x* seconds. Default value is `nil` (the keys will never expire).
+
+```ruby
+# config/initializers/superworker.rb
+Sidekiq::Superworker.options[:superjob_expiration] = 2592000 # 1 Month
+```
+
 ### Logging
 
 To make debugging easier, Sidekiq Superworker provides detailed log messages when its logger is set to the DEBUG level:

--- a/lib/sidekiq/superworker.rb
+++ b/lib/sidekiq/superworker.rb
@@ -9,7 +9,8 @@ module Sidekiq
   module Superworker
     DEFAULTS = {
       delete_subjobs_after_superjob_completes: true,
-      subjob_redis_prefix: 'subjob'
+      subjob_redis_prefix: 'subjob',
+      superjob_expiration: nil
     }
 
     def self.options


### PR DESCRIPTION
Adds the options to set an expiry time for the subjob keys. This can be helpful for example if subjobs fail and the superjob is never completed, so old subjob keys won't pollute redis. 